### PR TITLE
Fix composer requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "AFL-3.0"
   ],
   "require": {
-    "composer/composer": "<=1.10.20 || >=2.0.0 <=2.0.11",
+    "composer/composer": "<1.11 || >=2.0.0 <2.1",
     "composer-plugin-api": "^1.0 || ^2.0"
   },
   "require-dev": {


### PR DESCRIPTION
Composer version 1.10.20 (as defined in dependency) has a security vulnerability.

composer/composer (1.10.20)
---------------------------

 * CVE-2021-29472: Missing argument delimiter can lead to command execution via VCS repository URLs or source download URLs on systems with Mercurial
   https://github.com/composer/composer/security/advisories/GHSA-h5h8-pc6h-jvvx


This also fixes #23 (#24).