### PR TITLE
Declare return types to be compatible with composer 2.7+

### DIFF
--- a/src/Magento/ComposerRootUpdatePlugin/Plugin/Commands/OverrideRequireCommand.php
+++ b/src/Magento/ComposerRootUpdatePlugin/Plugin/Commands/OverrideRequireCommand.php
@@ -86,7 +86,7 @@ class OverrideRequireCommand extends ExtendableRequireCommand
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         parent::configure();
 
@@ -170,7 +170,7 @@ class OverrideRequireCommand extends ExtendableRequireCommand
      *
      * @throws Exception
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->console = new Console($this->getIO(), $input->getOption(self::INTERACTIVE_OPT));
         $this->pkgUtils = new PackageUtils($this->console);

--- a/src/Magento/ComposerRootUpdatePlugin/Plugin/Commands/OverrideRequireCommand.php
+++ b/src/Magento/ComposerRootUpdatePlugin/Plugin/Commands/OverrideRequireCommand.php
@@ -69,7 +69,7 @@ class OverrideRequireCommand extends ExtendableRequireCommand
      * @param Application|null $application
      * @return void
      */
-    public function setApplication(Application $application = null)
+    public function setApplication(Application $application = null): void
     {
         // For Composer versions below 2.1.6:
         // In order to trick Composer into overriding its native RequireCommand with this class, the name needs to be

--- a/src/Magento/ComposerRootUpdatePlugin/Plugin/Commands/RequireCommerceCommand.php
+++ b/src/Magento/ComposerRootUpdatePlugin/Plugin/Commands/RequireCommerceCommand.php
@@ -61,7 +61,7 @@ class RequireCommerceCommand extends ExtendableRequireCommand
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         parent::configure();
 
@@ -154,7 +154,7 @@ $pluginHeader
      *
      * @throws Exception
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->console = new Console($this->getIO(), $input->getOption(self::INTERACTIVE_OPT));
         $console = $this->console;


### PR DESCRIPTION
Composer 2.7 had to declare the return type for Command::execute() to be compatible with Symfony 7, leading to issues with this plugin https://github.com/composer/composer/issues/11843